### PR TITLE
Add missing p tag and use spam instead of other

### DIFF
--- a/src/lib/nostr.js
+++ b/src/lib/nostr.js
@@ -89,6 +89,11 @@ export default class Nostr {
 
   static async setTags(moderationNostrEvent, moderatedNostrEvent, moderation) {
     const reportType = this.inferReportType(moderation);
+    moderationNostrEvent.tags.push([
+      "p",
+      moderatedNostrEvent.pubkey,
+      reportType,
+    ]);
     moderationNostrEvent.tags.push(["e", moderatedNostrEvent.id, reportType]);
     moderationNostrEvent.tags.push(["L", "MOD"]);
 

--- a/src/lib/openAICategories.js
+++ b/src/lib/openAICategories.js
@@ -1,68 +1,68 @@
 const OPENAI_CATEGORIES = {
   hate: {
     description:
-      'Content that expresses, incites, or promotes hate based on race, gender, ethnicity, religion, nationality, sexual orientation, disability status, or caste. Hateful content aimed at non-protected groups (e.g., chess players) is harassment.',
-    nip56_report_type: 'other',
-    nip69: 'IH',
+      "Content that expresses, incites, or promotes hate based on race, gender, ethnicity, religion, nationality, sexual orientation, disability status, or caste. Hateful content aimed at non-protected groups (e.g., chess players) is harassment.",
+    nip56_report_type: "spam",
+    nip69: "IH",
   },
-  'hate/threatening': {
+  "hate/threatening": {
     description:
-      'Hateful content that also includes violence or serious harm towards the targeted group based on race, gender, ethnicity, religion, nationality, sexual orientation, disability status, or caste.',
-    nip56_report_type: 'other',
-    nip69: 'HC-bhd',
+      "Hateful content that also includes violence or serious harm towards the targeted group based on race, gender, ethnicity, religion, nationality, sexual orientation, disability status, or caste.",
+    nip56_report_type: "spam",
+    nip69: "HC-bhd",
   },
   harassment: {
     description:
-      'Content that expresses, incites, or promotes harassing language towards any target.',
-    nip56_report_type: 'other',
-    nip69: 'IL-har',
+      "Content that expresses, incites, or promotes harassing language towards any target.",
+    nip56_report_type: "spam",
+    nip69: "IL-har",
   },
-  'harassment/threatening': {
+  "harassment/threatening": {
     description:
-      'Harassment content that also includes violence or serious harm towards any target.',
-    nip56_report_type: 'other',
-    nip69: 'HC-bhd',
+      "Harassment content that also includes violence or serious harm towards any target.",
+    nip56_report_type: "spam",
+    nip69: "HC-bhd",
   },
-  'self-harm': {
+  "self-harm": {
     description:
-      'Content that promotes, encourages, or depicts acts of self-harm, such as suicide, cutting, and eating disorders.',
-    nip56_report_type: 'other',
-    nip69: 'HC-bhd',
+      "Content that promotes, encourages, or depicts acts of self-harm, such as suicide, cutting, and eating disorders.",
+    nip56_report_type: "spam",
+    nip69: "HC-bhd",
   },
-  'self-harm/intent': {
+  "self-harm/intent": {
     description:
-      'Content where the speaker expresses that they are engaging or intend to engage in acts of self-harm, such as suicide, cutting, and eating disorders.',
-    nip56_report_type: 'other',
-    nip69: 'HC-bhd',
+      "Content where the speaker expresses that they are engaging or intend to engage in acts of self-harm, such as suicide, cutting, and eating disorders.",
+    nip56_report_type: "spam",
+    nip69: "HC-bhd",
   },
-  'self-harm/instructions': {
+  "self-harm/instructions": {
     description:
-      'Content that encourages performing acts of self-harm, such as suicide, cutting, and eating disorders, or that gives instructions or advice on how to commit such acts.',
-    nip56_report_type: 'other',
-    nip69: 'HC-bhd',
+      "Content that encourages performing acts of self-harm, such as suicide, cutting, and eating disorders, or that gives instructions or advice on how to commit such acts.",
+    nip56_report_type: "spam",
+    nip69: "HC-bhd",
   },
   sexual: {
     description:
-      'Content meant to arouse sexual excitement, such as the description of sexual activity, or that promotes sexual services (excluding sex education and wellness).',
-    nip56_report_type: 'nudity',
-    nip69: 'NS',
+      "Content meant to arouse sexual excitement, such as the description of sexual activity, or that promotes sexual services (excluding sex education and wellness).",
+    nip56_report_type: "nudity",
+    nip69: "NS",
   },
-  'sexual/minors': {
+  "sexual/minors": {
     description:
-      'Sexual content that includes an individual who is under 18 years old.',
-    nip56_report_type: 'illegal',
-    nip69: 'IL-csa',
+      "Sexual content that includes an individual who is under 18 years old.",
+    nip56_report_type: "illegal",
+    nip69: "IL-csa",
   },
   violence: {
-    description: 'Content that depicts death, violence, or physical injury.',
-    nip56_report_type: 'other',
-    nip69: 'VI',
+    description: "Content that depicts death, violence, or physical injury.",
+    nip56_report_type: "spam",
+    nip69: "VI",
   },
-  'violence/graphic': {
+  "violence/graphic": {
     description:
-      'Content that depicts death, violence, or physical injury in graphic detail.',
-    nip56_report_type: 'other',
-    nip69: 'VI',
+      "Content that depicts death, violence, or physical injury in graphic detail.",
+    nip56_report_type: "spam",
+    nip69: "VI",
   },
 };
 

--- a/test/moderationFunction.test.js
+++ b/test/moderationFunction.test.js
@@ -45,7 +45,7 @@ const reportNostrEvent = {
     [
       "e",
       "d6548d08b8bc5dff67004ca072d717d95537ee66c2321f4adc40f0149de93188",
-      "other",
+      "spam",
     ],
     ["L", "MOD"],
     ["l", "hate", "MOD", '{"confidence":0.7413473725318909}'],
@@ -229,7 +229,8 @@ describe("Moderation Cloud Function", async () => {
     sinon.assert.calledWithMatch(Nostr.publishNostrEvent, {
       kind: 1984,
       tags: [
-        ["e", flaggedNostrEvent.id, "other"],
+        ["p", flaggedNostrEvent.pubkey, "spam"],
+        ["e", flaggedNostrEvent.id, "spam"],
         ["L", "MOD"],
         ["l", "MOD>IH", "MOD", sinon.match.string],
         ["l", "MOD>IL-har", "MOD", sinon.match.string],
@@ -293,7 +294,8 @@ describe("Moderation Cloud Function", async () => {
     sinon.assert.calledWithMatch(Nostr.publishNostrEvent, {
       kind: 1984,
       tags: [
-        ["e", flaggedNostrEvent.id, "other"],
+        ["p", flaggedNostrEvent.pubkey, "spam"],
+        ["e", flaggedNostrEvent.id, "spam"],
         ["L", "MOD"],
         ["l", "MOD>IH", "MOD", sinon.match.string],
         ["l", "MOD>IL-har", "MOD", sinon.match.string],
@@ -362,7 +364,8 @@ describe("Moderation Cloud Function", async () => {
     sinon.assert.calledWithMatch(Nostr.publishNostrEvent, {
       kind: 1984,
       tags: [
-        ["e", flaggedNostrEvent.id, "other"],
+        ["p", flaggedNostrEvent.pubkey, "spam"],
+        ["e", flaggedNostrEvent.id, "spam"],
         ["L", "MOD"],
         ["l", "MOD>IH", "MOD", sinon.match.string],
         ["l", "MOD>IL-har", "MOD", sinon.match.string],
@@ -428,7 +431,8 @@ describe("Moderation Cloud Function", async () => {
     sinon.assert.calledWithMatch(Nostr.publishNostrEvent, {
       kind: 1984,
       tags: [
-        ["e", flaggedNostrEvent.id, "other"],
+        ["p", flaggedNostrEvent.pubkey, "spam"],
+        ["e", flaggedNostrEvent.id, "spam"],
         ["L", "MOD"],
         ["l", "MOD>IH", "MOD", sinon.match.string],
         ["l", "MOD>IL-har", "MOD", sinon.match.string],


### PR DESCRIPTION
I noticed that we were missing a couple of details to correctly implement nip-56:
* We MUST include the `p` tag, nost just the `e` tag.
* The `other` category we were using for top level categories must be part of the spec, so it need to be one of these:
```
nudity - depictions of nudity, porn, etc.
profanity - profanity, hateful speech, etc.
illegal - something which may be illegal in some jurisdiction
spam - spam
impersonation - someone pretending to be someone else
```
I've chosen `spam` which seems to be the most generic one although still not matching perfectly of course.